### PR TITLE
added SupraOracles to Oracles section

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ This page introduces all links related to core and ecosystem development of Klay
  
 ## Oracles
 * [Witnet](https://feeds.witnet.io/klaytn)
+* [SupraOracles](https://data.supraoracles.com/networks/klaytn)
 
 ## Bridges
 * [Orbit Bridge](https://bridge.orbitchain.io/)


### PR DESCRIPTION
This PR adds _SupraOracles_ to the `Oracles` section of the repo. 

SupraOracles is integrated with Klaytn on testnet. You can see it in action here: 
- [Price feed data for Klaytn](https://data.supraoracles.com/networks/klaytn)
- [VRF](https://supraoracles.com/docs/vrf1/a-deeper-dive-into-supra-vrf) - (Klaytn network supported too.)
